### PR TITLE
Added link to Github Repo (Rebase of PR 26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This project was completed in [Typescript](http://www.typescriptlang.org/). For 
 
 This project uses the [Monaco (Visual Studio Code Online Editor)](https://github.com/Microsoft/monaco-editor) as its editor. You can find its definition in [monaco.d.ts](wwwroot/src/lib/monaco.d.ts)
 
-Run `complie.cmd` on any changes made to compile the Typescript into Javascript to use.
+Run `compile.cmd` on any changes made to compile the Typescript into Javascript to use.
 
 
 ### Submitting Contributions

--- a/wwwroot/bin/wptest.js
+++ b/wwwroot/bin/wptest.js
@@ -2455,6 +2455,10 @@ var SettingsDialog = new Tag().with({
                     React.createElement("button", { hidden: vm.settingsDialog.useMonaco$(), onclick: function (e) { return vm.settingsDialog.useMonaco$(true); }, style: "display: block" },
                         React.createElement("span", { class: "icon" }, "\u2699"),
                         "Enable the advanced text editor on this device from now on")),
+                React.createElement("label", { style: "display: block; margin-bottom: 10px" },
+                    React.createElement("a", { style: "display: block", href: "https://github.com/MicrosoftEdge/wptest", target: "_blank" },
+                        React.createElement("span", { class: "icon" }),
+                        "Contribute on Github")),
                 React.createElement("footer", { style: "margin-top: 20px" },
                     React.createElement("input", { type: "submit", value: "Close" })))));
 });

--- a/wwwroot/src/wptest.tsx
+++ b/wwwroot/src/wptest.tsx
@@ -1039,6 +1039,12 @@ var SettingsDialog = new Tag().with({
 						Enable the advanced text editor on this device from now on
 					</button>
 				</label>
+				<label style="display: block; margin-bottom: 10px">
+					<a style="display: block" href="https://github.com/MicrosoftEdge/wptest" target="_blank">
+						<span class="icon"></span>
+						Contribute on Github
+					</a>
+				</label>
 				<footer style="margin-top: 20px">
 					<input type="submit" value="Close" />
 				</footer>

--- a/wwwroot/style/wptest.css
+++ b/wwwroot/style/wptest.css
@@ -54,7 +54,8 @@ body > top-row > *, body > bottom-row > * {
 	body > dialog > section > h1 {
 		margin-top: 0;
 	}
-	body > dialog button {
+	body > dialog button,
+	body > dialog a[of="settings-dialog"] {
 		-webkit-appearance: none;
 		border: 1px solid;
 		background: #fff;
@@ -66,23 +67,32 @@ body > top-row > *, body > bottom-row > * {
 		transition: outline-width 0.1s;
 		cursor: pointer;
 		outline: 0px solid currentColor; outline-offset: -1px;
+		display: block;
 	}
-	body > dialog button:hover {
+	body > dialog button:hover,
+	body > dialog a[of="settings-dialog"]:hover {
 		color: red;
 		outline: 4px solid currentColor;
 	}
-	body > dialog button:focus {
+	body > dialog button:focus,
+	body > dialog a[of="settings-dialog"]:focus {
 		color: red;
 		outline: 4px solid currentColor;
 	}
-	body > dialog button:active {
+	body > dialog button:active,
+	body > dialog a[of="settings-dialog"]:active {
 		color: purple; border-color: red; outline-color: red;
 	}
 
 /* } */
 
-button[of="settings-dialog"] {
-	width: 100%; text-align: left;
+button[of="settings-dialog"],
+a[of="settings-dialog"] {
+	width: 100%; text-align: left; display: block;
+}
+
+a[of="settings-dialog"] {
+	text-decoration: none;
 }
 
 button[of="settings-dialog"] > span.icon {


### PR DESCRIPTION
> To hopefully gain PRs to improve this, I've added a link to the GitHub repo and associated styles to make the link look similar to that of the buttons but keep its semantic markup. 
> 
> Additionally, fixed typo in the repo's README. 
>
> @gregwhitworth